### PR TITLE
Add dropdown page navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,48 @@
 5.  フォームに記入して送信します。
 6.  データ概要ページで、表示するデータ（すべてのデータ、資産の傾向、カテゴリの支出、収入の傾向、定期契約の傾向、特別支出の傾向、旅行費用）を選択します。
 7.  データ削除ページで、削除する行を選択してフォームを送信します。
+
+## Laravel Backend & Node Frontend
+
+The `backend-laravel` directory contains a minimal API built with Laravel. Basic CRUD endpoints are available for main categories, sub categories and transactions. To start the API server:
+
+```bash
+cd backend-laravel
+composer install
+php artisan migrate --seed
+php artisan serve
+```
+
+The `migrate --seed` command creates the schema and loads sample categories and
+transactions from `kakeibo_data.json`. Run it once when setting up the backend
+locally or whenever you want to reset the data.
+
+The JS frontend in `frontend-js` can be launched with Node.js. It communicates with the Laravel API and lets you manage transactions via a browser.
+
+```bash
+cd ../frontend-js
+npm install
+npm start
+```
+
+Open `http://localhost:3000` in your browser while the Laravel backend is running on port `8000`.
+
+The frontend interface is in Japanese. It supports filtering transactions by month range as well as main and sub categories. A Chart.js graph visualizes income, expense and asset trends. Use the **Page** dropdown to switch between the input form, data overview and bulk deletion pages.
+
+## Testing
+
+Run API tests inside the Laravel directory:
+
+```bash
+cd backend-laravel
+composer install
+php artisan test
+```
+
+Run frontend utility tests:
+
+```bash
+cd ../frontend-js
+npm test
+```
+

--- a/backend-laravel/bootstrap/app.php
+++ b/backend-laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/backend-laravel/routes/api.php
+++ b/backend-laravel/routes/api.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Models\MainCategory;
+use App\Models\SubCategory;
+use App\Models\Transaction;
+use Illuminate\Http\Request;
+
+Route::get('/main_categories', function () {
+    return MainCategory::all();
+});
+
+Route::get('/main_categories/{mainCategory}', function (MainCategory $mainCategory) {
+    return $mainCategory;
+});
+
+Route::post('/main_categories', function (Request $request) {
+    return MainCategory::create($request->all());
+});
+
+Route::put('/main_categories/{mainCategory}', function (MainCategory $mainCategory, Request $request) {
+    $mainCategory->update($request->all());
+    return $mainCategory;
+});
+
+Route::delete('/main_categories/{mainCategory}', function (MainCategory $mainCategory) {
+    $mainCategory->delete();
+    return response()->json(['message' => 'Deleted']);
+});
+
+Route::get('/sub_categories', function () {
+    return SubCategory::all();
+});
+
+Route::get('/sub_categories/{subCategory}', function (SubCategory $subCategory) {
+    return $subCategory;
+});
+
+Route::post('/sub_categories', function (Request $request) {
+    return SubCategory::create($request->all());
+});
+
+Route::put('/sub_categories/{subCategory}', function (SubCategory $subCategory, Request $request) {
+    $subCategory->update($request->all());
+    return $subCategory;
+});
+
+Route::delete('/sub_categories/{subCategory}', function (SubCategory $subCategory) {
+    $subCategory->delete();
+    return response()->json(['message' => 'Deleted']);
+});
+
+Route::get('/transactions', function () {
+    return Transaction::all();
+});
+
+Route::get('/transactions/{transaction}', function (Transaction $transaction) {
+    return $transaction;
+});
+
+Route::post('/transactions', function () {
+    return Transaction::create(request()->all());
+});
+
+Route::put('/transactions/{transaction}', function (Transaction $transaction) {
+    $transaction->update(request()->all());
+    return $transaction;
+});
+
+Route::delete('/transactions/{transaction}', function (Transaction $transaction) {
+    $transaction->delete();
+    return response()->json(['message' => 'Deleted']);
+});
+
+Route::get('/month-summary/{month}', function ($month) {
+    $summary = Transaction::selectRaw('sub_categories.name as sub_category_name, type, SUM(amount) as total')
+        ->join('sub_categories', 'transactions.sub_category_id', '=', 'sub_categories.id')
+        ->join('main_categories', 'sub_categories.main_category_id', '=', 'main_categories.id')
+        ->where('main_categories.name', '日常')
+        ->where('transactions.date', 'like', "$month%")
+        ->groupBy('sub_category_name', 'type')
+        ->get();
+
+    $budget = $summary->where('type', '予算')->pluck('total', 'sub_category_name');
+    $spent = $summary->where('type', '支出')->pluck('total', 'sub_category_name');
+    return ['spent' => $spent, 'budget' => $budget];
+});

--- a/backend-laravel/routes/web.php
+++ b/backend-laravel/routes/web.php
@@ -1,36 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Models\MainCategory;
-use App\Models\SubCategory;
-use App\Models\Transaction;
 
 Route::get('/', function () {
     return view('welcome');
-});
-
-Route::get('/api/main_categories', function () {
-    return MainCategory::all();
-});
-
-Route::get('/api/sub_categories', function () {
-    return SubCategory::all();
-});
-
-Route::get('/api/transactions', function () {
-    return Transaction::all();
-});
-
-Route::post('/api/transactions', function () {
-    return Transaction::create(request()->all());
-});
-
-Route::put('/api/transactions/{transaction}', function (Transaction $transaction) {
-    $transaction->update(request()->all());
-    return $transaction;
-});
-
-Route::delete('/api/transactions/{transaction}', function (Transaction $transaction) {
-    $transaction->delete();
-    return response()->json(['message' => 'Deleted']);
 });

--- a/backend-laravel/tests/Feature/TransactionApiTest.php
+++ b/backend-laravel/tests/Feature/TransactionApiTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\MainCategory;
+use App\Models\SubCategory;
+use App\Models\Transaction;
+
+class TransactionApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crud_flow(): void
+    {
+        $main = MainCategory::create(['name' => 'Daily']);
+        $sub = $main->subCategories()->create(['name' => 'Food']);
+
+        $data = [
+            'sub_category_id' => $sub->id,
+            'amount' => 100,
+            'type' => '支出',
+            'date' => '2025-01-01',
+            'detail' => 'test detail',
+        ];
+
+        $create = $this->post('/api/transactions', $data);
+        $create->assertStatus(200);
+        $this->assertDatabaseHas('transactions', ['detail' => 'test detail']);
+
+        $id = Transaction::first()->id;
+
+        $update = $this->put("/api/transactions/{$id}", ['detail' => 'updated']);
+        $update->assertStatus(200)
+               ->assertJsonFragment(['detail' => 'updated']);
+        $this->assertDatabaseHas('transactions', ['id' => $id, 'detail' => 'updated']);
+
+        $delete = $this->delete("/api/transactions/{$id}");
+        $delete->assertStatus(200);
+        $this->assertDatabaseMissing('transactions', ['id' => $id]);
+    }
+
+    public function test_monthly_summary_endpoint(): void
+    {
+        $main = MainCategory::create(['name' => '日常']);
+        $sub = $main->subCategories()->create(['name' => 'Food']);
+
+        Transaction::create([
+            'sub_category_id' => $sub->id,
+            'amount' => 50,
+            'type' => '支出',
+            'date' => '2025-07-01',
+        ]);
+
+        Transaction::create([
+            'sub_category_id' => $sub->id,
+            'amount' => 200,
+            'type' => '予算',
+            'date' => '2025-07-01',
+        ]);
+
+        $response = $this->get('/api/month-summary/2025-07');
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'spent' => ['Food' => 50],
+                     'budget' => ['Food' => 200],
+                 ]);
+    }
+}

--- a/frontend-js/README.md
+++ b/frontend-js/README.md
@@ -1,0 +1,31 @@
+# Frontend JS
+
+This is a minimal Node.js frontend for the Laravel backend.
+
+## Setup
+
+```bash
+npm install
+```
+
+## Run
+
+```bash
+npm start
+```
+
+The application will be available at `http://localhost:3000` and expects the Laravel API to run at `http://localhost:8000`.
+
+## Features
+
+- Add and edit transactions with inline table actions
+- Filter transactions by month range and by main/sub category
+- Visualize income, expense and cumulative asset in a line chart powered by Chart.js
+- Navigate between pages using the dropdown at the top (Add Transaction, View Data, Delete Data)
+- Interface is displayed in Japanese
+
+## Test
+
+```bash
+npm test
+```

--- a/frontend-js/index.html
+++ b/frontend-js/index.html
@@ -1,68 +1,119 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Kakeibo App</title>
+    <title>家計簿アプリ</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="style.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="utils.js"></script>
 </head>
 <body>
     <div class="container">
-        <h1>Kakeibo App</h1>
-        <div class="row">
+        <h1>家計簿アプリ</h1>
+        <div class="mb-3">
+            <label class="form-label">ページ</label>
+            <select id="page-select" class="form-select w-auto d-inline-block">
+                <option value="input">入力</option>
+                <option value="data">データ</option>
+                <option value="delete">削除</option>
+            </select>
+        </div>
+        <div id="page-input" class="page-section row">
             <div class="col-md-4">
-                <h2>Add Transaction</h2>
+                <h2>取引追加</h2>
                 <form id="add-transaction-form">
                     <div class="mb-3">
-                        <label for="main-category" class="form-label">Main Category</label>
+                        <label for="main-category" class="form-label">大カテゴリ</label>
                         <select id="main-category" class="form-select"></select>
                     </div>
                     <div class="mb-3">
-                        <label for="sub-category" class="form-label">Sub Category</label>
+                        <label for="sub-category" class="form-label">小カテゴリ</label>
                         <select id="sub-category" class="form-select"></select>
                     </div>
                     <div class="mb-3">
-                        <label for="date" class="form-label">Date</label>
+                        <label for="date" class="form-label">日付</label>
                         <input type="date" id="date" class="form-control">
                     </div>
                     <div class="mb-3">
-                        <label for="type" class="form-label">Type</label>
+                        <label for="type" class="form-label">種別</label>
                         <select id="type" class="form-select">
-                            <option value="支出">Expense</option>
-                            <option value="収入">Income</option>
-                            <option value="予算">Budget</option>
+                            <option value="支出">支出</option>
+                            <option value="収入">収入</option>
+                            <option value="予算">予算</option>
                         </select>
                     </div>
                     <div class="mb-3">
-                        <label for="detail" class="form-label">Detail</label>
+                        <label for="detail" class="form-label">詳細</label>
                         <input type="text" id="detail" class="form-control">
                     </div>
                     <div class="mb-3">
-                        <label for="amount" class="form-label">Amount</label>
+                        <label for="amount" class="form-label">金額</label>
                         <input type="number" id="amount" class="form-control">
                     </div>
-                    <button type="submit" class="btn btn-primary">Add</button>
+                    <button type="submit" class="btn btn-primary">追加</button>
                 </form>
             </div>
-            <div class="col-md-8">
-                <h2>Transactions</h2>
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Main Category</th>
-                            <th>Sub Category</th>
-                            <th>Type</th>
-                            <th>Detail</th>
-                            <th>Amount</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody id="transactions-table-body">
-                    </tbody>
-                </table>
+        </div>
+
+        <div id="page-data" class="page-section" style="display:none;">
+            <h2>取引一覧</h2>
+            <div class="row mb-3">
+                <div class="col">
+                    <label class="form-label">開始月</label>
+                    <input type="month" id="start-month" class="form-control">
+                </div>
+                <div class="col">
+                    <label class="form-label">終了月</label>
+                    <input type="month" id="end-month" class="form-control">
+                </div>
+                <div class="col">
+                    <label class="form-label">大カテゴリ</label>
+                    <select id="filter-main-category" class="form-select"></select>
+                </div>
+                <div class="col">
+                    <label class="form-label">小カテゴリ</label>
+                    <select id="filter-sub-category" class="form-select"></select>
+                </div>
+                <div class="col d-flex align-items-end">
+                    <button id="filter-btn" class="btn btn-primary w-100">適用</button>
+                </div>
             </div>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>日付</th>
+                        <th>大カテゴリ</th>
+                        <th>小カテゴリ</th>
+                        <th>種別</th>
+                        <th>詳細</th>
+                        <th>金額</th>
+                        <th>操作</th>
+                    </tr>
+                </thead>
+                <tbody id="transactions-table-body"></tbody>
+            </table>
+            <canvas id="line-chart" height="100"></canvas>
+        </div>
+
+        <div id="page-delete" class="page-section" style="display:none;">
+            <h2>取引削除</h2>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>日付</th>
+                        <th>大カテゴリ</th>
+                        <th>小カテゴリ</th>
+                        <th>種別</th>
+                        <th>詳細</th>
+                        <th>金額</th>
+                    </tr>
+                </thead>
+                <tbody id="delete-table-body"></tbody>
+            </table>
+            <button id="delete-btn" class="btn btn-danger">選択削除</button>
         </div>
     </div>
     <script src="app.js"></script>

--- a/frontend-js/package.json
+++ b/frontend-js/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "kakeibo-frontend",
+  "version": "1.0.0",
+  "description": "Simple Node.js frontend for Kakeibo app",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node test_utils.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/frontend-js/server.js
+++ b/frontend-js/server.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname)));
+
+app.listen(PORT, () => {
+  console.log(`Frontend running at http://localhost:${PORT}`);
+});

--- a/frontend-js/style.css
+++ b/frontend-js/style.css
@@ -1,0 +1,7 @@
+/* hide all sections by default */
+.page-section {
+  display: none;
+}
+
+/* allow first page to be visible on load via inline style or JS */
+

--- a/frontend-js/test_utils.js
+++ b/frontend-js/test_utils.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { filterTransactions, monthlyChartData } = require('./utils');
+
+const data = [
+  { date: '2025-07-01', type: '収入', amount: 100, sub_category_id: 1 },
+  { date: '2025-07-02', type: '支出', amount: 50, sub_category_id: 1 },
+  { date: '2025-08-01', type: '支出', amount: 30, sub_category_id: 1 }
+];
+
+const filtered = filterTransactions(data, '2025-07', '2025-07');
+assert.strictEqual(filtered.length, 2);
+
+const chart = monthlyChartData(filtered);
+assert.deepStrictEqual(chart.months, ['2025-07']);
+assert.deepStrictEqual(chart.income, [100]);
+assert.deepStrictEqual(chart.expense, [50]);
+console.log('utils tests passed');
+

--- a/frontend-js/utils.js
+++ b/frontend-js/utils.js
@@ -1,0 +1,43 @@
+(function(root, factory){
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.utils = factory();
+  }
+}(this, function(){
+  function filterTransactions(transactions, startMonth, endMonth) {
+    return transactions.filter(t => {
+      const m = t.date.slice(0,7);
+      if (startMonth && m < startMonth) return false;
+      if (endMonth && m > endMonth) return false;
+      return true;
+    });
+  }
+
+  function monthlyChartData(transactions) {
+    const map = {};
+    transactions.forEach(t => {
+      const month = t.date.slice(0,7);
+      if (!map[month]) map[month] = {income:0, expense:0};
+      if (t.type === '収入') map[month].income += Number(t.amount);
+      if (t.type === '支出') map[month].expense += Number(t.amount);
+    });
+    const months = Object.keys(map).sort();
+    const income = [];
+    const expense = [];
+    const asset = [];
+    let acc = 0;
+    months.forEach(m => {
+      const i = map[m].income;
+      const e = map[m].expense;
+      income.push(i);
+      expense.push(e);
+      acc += i - e;
+      asset.push(acc);
+    });
+    return {months, income, expense, asset};
+  }
+
+  return {filterTransactions, monthlyChartData};
+}));
+


### PR DESCRIPTION
## Summary
- let the frontend switch between pages via a dropdown
- add bulk delete view and update scripts
- document navigation in READMEs
- add category filters and Japanese UI

## Testing
- `node -v`
- `npm test --prefix frontend-js`
- `php -v`
- `php backend-laravel/artisan test` *(fails: vendor autoload not found)*
- `composer install --working-dir=backend-laravel` *(fails to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_687c919ca7bc83278baf7870be683f9c