### PR TITLE
Add React frontend skeleton

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,29 @@
+# React Frontend
+
+This folder contains a simple React app built with [Vite](https://vitejs.dev/).
+It communicates with a Laravel backend via REST API endpoints.
+
+## Prerequisites
+
+- Node.js and npm installed
+- Install dependencies with `npm install`
+
+## Development server
+
+```
+npm run dev
+```
+
+The app expects the backend API base URL to be set with the `REACT_APP_API_BASE_URL` environment variable. If not set, it defaults to `http://localhost:8000/api`.
+
+## Build for production
+
+```
+npm run build
+```
+
+## Preview production build
+
+```
+npm run preview
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react'
+import { listItems, createItem, updateItem, deleteItem } from './api'
+import ItemList from './components/ItemList'
+import ItemForm from './components/ItemForm'
+
+export default function App() {
+  const [items, setItems] = useState([])
+  const [view, setView] = useState('list')
+  const [editingItem, setEditingItem] = useState(null)
+
+  useEffect(() => {
+    fetchItems()
+  }, [])
+
+  const fetchItems = async () => {
+    const data = await listItems()
+    setItems(data)
+  }
+
+  const handleCreate = async (item) => {
+    await createItem(item)
+    await fetchItems()
+    setView('list')
+  }
+
+  const handleUpdate = async (item) => {
+    await updateItem(item)
+    await fetchItems()
+    setView('list')
+  }
+
+  const handleDelete = async (id) => {
+    await deleteItem(id)
+    await fetchItems()
+  }
+
+  const startEdit = (item) => {
+    setEditingItem(item)
+    setView('edit')
+  }
+
+  return (
+    <div>
+      <h1>Items</h1>
+      {view === 'list' && (
+        <>
+          <button onClick={() => setView('create')}>Create Item</button>
+          <ItemList items={items} onEdit={startEdit} onDelete={handleDelete} />
+        </>
+      )}
+      {view === "create" && (
+        <ItemForm onSubmit={handleCreate} onCancel={() => setView("list")} />
+      )}
+      {view === "edit" && (
+        <ItemForm item={editingItem} onSubmit={handleUpdate} onCancel={() => setView("list")} />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,34 @@
+const BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000/api'
+
+export async function listItems() {
+  const res = await fetch(`${BASE_URL}/items`)
+  if (!res.ok) throw new Error('Failed to fetch items')
+  return res.json()
+}
+
+export async function createItem(item) {
+  const res = await fetch(`${BASE_URL}/items`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(item),
+  })
+  if (!res.ok) throw new Error('Failed to create item')
+  return res.json()
+}
+
+export async function updateItem(item) {
+  const res = await fetch(`${BASE_URL}/items/${item.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(item),
+  })
+  if (!res.ok) throw new Error('Failed to update item')
+  return res.json()
+}
+
+export async function deleteItem(id) {
+  const res = await fetch(`${BASE_URL}/items/${id}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok) throw new Error('Failed to delete item')
+}

--- a/frontend/src/components/ItemForm.jsx
+++ b/frontend/src/components/ItemForm.jsx
@@ -1,0 +1,24 @@
+import React, { useState, useEffect } from 'react'
+
+export default function ItemForm({ item, onSubmit, onCancel }) {
+  const [name, setName] = useState('')
+
+  useEffect(() => {
+    if (item) {
+      setName(item.name)
+    }
+  }, [item])
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    onSubmit({ ...item, name })
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={name} onChange={e => setName(e.target.value)} placeholder="Item name" />
+      <button type="submit">Save</button>
+      <button type="button" onClick={onCancel}>Cancel</button>
+    </form>
+  )
+}

--- a/frontend/src/components/ItemList.jsx
+++ b/frontend/src/components/ItemList.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export default function ItemList({ items, onEdit, onDelete }) {
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          {item.name}
+          <button onClick={() => onEdit(item)}>Edit</button>
+          <button onClick={() => onDelete(item.id)}>Delete</button>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- set up a React project in `frontend/` using a Vite-style layout
- implement components for listing items and a form for create/edit
- add API helper for CRUD operations against the Laravel backend
- provide a basic `App.jsx` layout to navigate between views
- document frontend setup and usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_687cd6453cb88327b1ee3cd6c90f1bf2