### PR TITLE
Add Laravel backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ test.py
 secrets.toml
 inventory.db
 kakeibo.db
+# Laravel
+backend/vendor/
+backend/.env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,14 @@
+APP_NAME=Laravel
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=root
+DB_PASSWORD=

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,37 @@
+# Backend Setup
+
+This directory contains a minimal Laravel application used by the project.
+
+## Setup
+
+1. Install PHP (>=8.1) and Composer.
+2. Run `composer install` inside this directory.
+3. Copy `.env.example` to `.env` and adjust your database credentials.
+4. Generate an application key:
+
+   ```
+   php artisan key:generate
+   ```
+
+5. Run database migrations:
+
+   ```
+   php artisan migrate
+   ```
+
+## Example `.env`
+
+```env
+APP_NAME=Laravel
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=root
+DB_PASSWORD=
+```

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Illuminate\Console\Scheduling\Schedule;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        //
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+    }
+}

--- a/backend/app/Exceptions/Handler.php
+++ b/backend/app/Exceptions/Handler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    protected $levels = [
+        //
+    ];
+
+    protected $dontReport = [
+        //
+    ];
+
+    protected $dontFlash = [
+        'current_password',
+        'password',
+        'password_confirmation',
+    ];
+
+    public function register(): void
+    {
+        //
+    }
+}

--- a/backend/app/Http/Controllers/ItemController.php
+++ b/backend/app/Http/Controllers/ItemController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Item;
+use Illuminate\Http\Request;
+
+class ItemController extends Controller
+{
+    public function index()
+    {
+        return Item::all();
+    }
+
+    public function store(Request $request)
+    {
+        $item = Item::create($request->only(['name', 'description']));
+        return response()->json($item, 201);
+    }
+
+    public function show(Item $item)
+    {
+        return $item;
+    }
+
+    public function update(Request $request, Item $item)
+    {
+        $item->update($request->only(['name', 'description']));
+        return response()->json($item);
+    }
+
+    public function destroy(Item $item)
+    {
+        $item->delete();
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middleware = [
+        //
+    ];
+
+    protected $middlewareGroups = [
+        'api' => [
+            'throttle:api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
+
+    protected $routeMiddleware = [
+        'auth' => \App\Http\Middleware\Authenticate::class,
+    ];
+}

--- a/backend/app/Http/Middleware/Authenticate.php
+++ b/backend/app/Http/Middleware/Authenticate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
+
+class Authenticate extends Middleware
+{
+    protected function redirectTo($request)
+    {
+        return null;
+    }
+}

--- a/backend/app/Models/Item.php
+++ b/backend/app/Models/Item.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Item extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+}

--- a/backend/artisan
+++ b/backend/artisan
@@ -1,0 +1,17 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__.'/vendor/autoload.php';
+
+$app = require_once __DIR__.'/bootstrap/app.php';
+
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+
+$status = $kernel->handle(
+    $input = new Symfony\Component\Console\Input\ArgvInput(),
+    new Symfony\Component\Console\Output\ConsoleOutput()
+);
+
+$kernel->terminate($input, $status);
+
+exit($status);

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Foundation\Application;
+
+$app = new Application(
+    dirname(__DIR__)
+);
+
+$app->singleton(
+    Illuminate\Contracts\Console\Kernel::class,
+    App\Console\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Http\Kernel::class,
+    App\Http\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    App\Exceptions\Handler::class
+);
+
+return $app;

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "example/backend",
+    "type": "project",
+    "require": {
+        "php": "^8.1",
+        "laravel/framework": "^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/backend/database/migrations/2024_01_01_000000_create_items_table.php
+++ b/backend/database/migrations/2024_01_01_000000_create_items_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('items', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('items');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ItemController;
+
+Route::middleware('api')->group(function () {
+    Route::apiResource('items', ItemController::class);
+});


### PR DESCRIPTION
## Summary
- add backend folder with a minimal Laravel skeleton
- create Item model and migration
- implement ItemController with CRUD actions
- define API routes for Item resource
- document setup instructions and example env config
- ignore backend vendor and env files

## Testing
- `php -l backend/app/Http/Controllers/ItemController.php`
- `php -l backend/app/Models/Item.php`
- `php -l backend/routes/api.php`
- `php -l backend/database/migrations/2024_01_01_000000_create_items_table.php`
- `php -l backend/app/Console/Kernel.php`
- `php -l backend/app/Exceptions/Handler.php`
- `php -l backend/app/Http/Kernel.php`
- `php -l backend/app/Http/Middleware/Authenticate.php`


------
https://chatgpt.com/codex/tasks/task_e_687cd642ec048327844a84fea62de5bd